### PR TITLE
Fix transport context

### DIFF
--- a/main.go
+++ b/main.go
@@ -173,9 +173,7 @@ func createGCMServer() (v1.API, error) {
 		option.WithScopes("https://www.googleapis.com/auth/monitoring.read"),
 		option.WithCredentialsFile(*credentialsFile),
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	transport, err := apihttp.NewTransport(ctx, http.DefaultTransport, opts...)
+	transport, err := apihttp.NewTransport(context.Background(), http.DefaultTransport, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating proxy HTTP transport: %s", err)
 	}


### PR DESCRIPTION
Cancelling the context causes all queries to fail because fetching a token requires making a request.