### PR TITLE
feat: add docker compose example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.21
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY *.go ./
+
+RUN go build -o thanos-promql-connector
+ENTRYPOINT ["./thanos-promql-connector"]

--- a/examples/prometheus-and-gmp/README.md
+++ b/examples/prometheus-and-gmp/README.md
@@ -1,0 +1,22 @@
+# <b>Example:</b> Connecting Thanos Querier to Prometheus and Google Managed Service for Prometheus (GMP)
+
+This example demonstrates how to connect Thanos Querier to two Prometheus instances and one Google Managed Service for Prometheus (GMP) instance. It provides a clear reference for setting up your own Thanos Querier configuration.
+
+## Prerequisites:
+
+- Docker environment.
+- Google Cloud Project with GMP enabled.
+- Google Cloud Service Account with the following roles:
+    - Monitoring Viewer
+    - Metric Writer
+- The service account JSON key file downloaded.
+
+## Run Instructions:
+1. <b>Edit</b> docker-compose.yml:
+    - Insert your `<PROJECT_ID>` on line 44.
+    - Replace `<SERVICE_ACCOUNT_CREDENTIAL_FILE_PATH>` on line 47 with the path to your service account file.
+2. <b>Start the services:</b> Run the following command:
+    ```bash
+    docker compose up
+    ```
+3. <b>Access the UI:</b> Open the Thanos Querier UI in your web browser at http://localhost:10902/. You should be able to query metrics from both your Prometheus instances and your GMP instance.

--- a/examples/prometheus-and-gmp/docker-compose.yml
+++ b/examples/prometheus-and-gmp/docker-compose.yml
@@ -1,0 +1,59 @@
+version: "2"
+
+services:
+  prom-1:
+    image: quay.io/prometheus/prometheus
+    command:
+    - --config.file=/etc/prometheus/prometheus.yml
+    volumes:
+    - ./prometheus-1.yml:/etc/prometheus/prometheus.yml
+  sidecar-1:
+    image: quay.io/thanos/thanos:v0.34.1
+    command:
+    - sidecar
+    - --prometheus.url=http://prom-1:9090
+  querier-1:
+    image: quay.io/thanos/thanos:v0.34.1
+    command:
+    - query
+    - --endpoint=sidecar-1:10901
+
+  prom-2:
+    image: quay.io/prometheus/prometheus
+    command:
+    - --config.file=/etc/prometheus/prometheus.yml
+    volumes:
+    - ./prometheus-2.yml:/etc/prometheus/prometheus.yml
+
+  sidecar-2:
+    image: quay.io/thanos/thanos:v0.34.1
+    command:
+    - sidecar
+    - --prometheus.url=http://prom-2:9090
+  querier-2:
+    image: quay.io/thanos/thanos:v0.34.1
+    command:
+    - query
+    - --endpoint=sidecar-2:10901
+
+  querier-3:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    command:
+    - --query.target-url=https://monitoring.googleapis.com/v1/projects/<PROJECT_ID>/location/global/prometheus
+    - --query.credentials-file=/key.json
+    volumes:
+    - <SERVICE_ACCOUNT_CREDENTIAL_FILE_PATH>:/key.json
+
+  querier:
+    image: quay.io/thanos/thanos:v0.34.1
+    command:
+    - query
+    - --endpoint-strict=querier-1:10901
+    - --endpoint-strict=querier-2:10901
+    - --endpoint-strict=querier-3:8081
+    - --query.mode=distributed
+    - --query.promql-engine=thanos
+    ports:
+    - "10902:10902"

--- a/examples/prometheus-and-gmp/prometheus-1.yml
+++ b/examples/prometheus-and-gmp/prometheus-1.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    cluster: us1
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ["localhost:9090"]

--- a/examples/prometheus-and-gmp/prometheus-2.yml
+++ b/examples/prometheus-and-gmp/prometheus-2.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    cluster: us2
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ["localhost:9090"]


### PR DESCRIPTION
This is an example that demonstrates how to connect Thanos Querier to two Prometheus instances and one Google Managed Service for Prometheus (GMP) instance.